### PR TITLE
convert inertia-link to a functional component

### DIFF
--- a/src/inertia-link.js
+++ b/src/inertia-link.js
@@ -1,6 +1,7 @@
 import Inertia, { shouldIntercept } from 'inertia'
 
 export default {
+  functional: true,
   props: {
     href: String,
     method: {
@@ -16,26 +17,27 @@ export default {
       default: false,
     },
   },
-  methods: {
-    visit(event) {
+  render: function(h, { props, data, children }) {
+    const visit = function (event) {
       if (shouldIntercept(event)) {
         event.preventDefault()
-        Inertia.visit(this.href, {
-          method: this.method,
-          replace: this.replace,
-          preserveScroll: this.preserveScroll,
+        Inertia.visit(props.href, {
+          method: props.method,
+          replace: props.replace,
+          preserveScroll: props.preserveScroll,
         })
       }
-    },
-  },
-  render: function(h) {
+    }
     return h('a', {
+      ...data,
       attrs: {
-        href: this.href,
+        ...data.attrs,
+        href: props.href,
       },
       on: {
-        click: this.visit,
+        ...data.on || {},
+        click: visit,
       },
-    }, this.$slots.default)
+    }, children)
   },
 }


### PR DESCRIPTION
Currently the `<inertia-link>` component is a regular stateful component.

When converting a project to use inertia I faced a case where I used scoped styles inside components to style the links and markup inside it (svg icon), but had to use the `/deep/` selector to be able to style the link's children elements after changing the anchor tags to `inertia-link`, as a regular component creates a new scope for its children elements.

Changing the `<inertia-link>` to a functional component solves this issue.
