### PR TITLE
Add "sass" file processing back into webpack.mix.js

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,15 +22,16 @@ Here is an example Webpack configuration that uses [Laravel Mix](https://github.
 const mix = require('laravel-mix')
 const path = require('path')
 
-mix.js('resources/js/app.js', 'public/js').webpackConfig({
-  output: { chunkFilename: 'js/[name].[contenthash].js' },
-  resolve: {
-    alias: {
-      'vue$': 'vue/dist/vue.runtime.js',
-      '@': path.resolve('resources/js'),
+mix.sass('resources/sass/app.scss', 'public/css')
+  .js('resources/js/app.js', 'public/js').webpackConfig({
+    output: { chunkFilename: 'js/[name].[contenthash].js' },
+    resolve: {
+      alias: {
+        'vue$': 'vue/dist/vue.runtime.js',
+        '@': path.resolve('resources/js'),
+      },
     },
-  },
-})
+  })
 ~~~
 
 ## Setup dynamic imports


### PR DESCRIPTION
I copied your `app.blade.php` file from the `inertiajs/inertia-laravel` repo, which references `mix('/css/app.css')`, but when I copied over the `webpack.mix.js` file from the `inertiajs/inertia-vue` repo, I got an error because mix couldn't find the asset.

I recommend keeping the `.sass` processing in the `webpack.mix.js` file to keep close to the Laravel default.