### PR TITLE
Remove "we recommend code splitting" because confusion

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,7 @@ mix.js('resources/js/app.js', 'public/js').webpackConfig({
 
 ## Setup dynamic imports
 
-We recommend using code splitting with Inertia.js. To do this we need to enable [dynamic imports](https://github.com/tc39/proposal-dynamic-import). We'll use a Babel plugin to make this work. First, install the plugin:
+By default, Inertia.js uses code splitting. To do this we need to enable [dynamic imports](https://github.com/tc39/proposal-dynamic-import). We'll use a Babel plugin to make this work. First, install the plugin:
 
 ~~~sh
 npm install @babel/plugin-syntax-dynamic-import --save


### PR DESCRIPTION
When I was just scanning to get everything installed, I glanced at "We recommend" and thought: ok, this step is optional if I want the optimization, but right now I just want to get the thing working. Then pretty soon after I hit an error caused by pasting in the "import()" into app.js. I then went back and installed the babel plugins.

2 thoughts:
1) Maybe just leave out code-splitting for the initial setup and have an extra section at the end for it
2) Pull in this PR or close it and use your own wording that doesn't suggest the step is optional or other future steps depend on it.

Take it or leave it brutha.