### PR TITLE
Add before after visit hooks

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -89,12 +89,16 @@ new Vue({
       resolveComponent: (component) => {
         return import(`@/Pages/${component}`).then(module => module.default)
       },
+      beforeVisit: () => { /* start loading indicator */ },
+      afterVisit: () => { /* stop loading indicator */ },
     },
   }),
 }).$mount(app)
 ~~~
 
 The `resolveComponent` is a callback that tells Inertia how to load a page component. This callback must return a promise with a page instance.
+
+The `beforeVisit` and `afterVisit` is an optional callback to overwrite the usage of [nprogress](http://ricostacruz.com/nprogress/) as a loading indicator. 
 
 ## Creating a base layout
 

--- a/src/app.js
+++ b/src/app.js
@@ -5,6 +5,14 @@ export default {
   props: {
     initialPage: Object,
     resolveComponent: Function,
+    beforeVisit: {
+      type: Function,
+      default: null
+    },
+    afterVisit: {
+      type: Function,
+      default: null
+    },
   },
   provide() {
     return {
@@ -20,12 +28,17 @@ export default {
     }
   },
   created() {
-    Inertia.init(this.initialPage, (page) => {
-      return Promise.resolve(this.resolveComponent(page.component)).then(instance => {
-        this.page.instance = instance
-        this.page.props = page.props
-      })
-    })
+    Inertia.init(
+      this.initialPage,
+      (page) => {
+        return Promise.resolve(this.resolveComponent(page.component)).then(instance => {
+          this.page.instance = instance
+          this.page.props = page.props
+        })
+      },
+      this.beforeVisit,
+      this.afterVisit
+    )
   },
   render(h) {
     if (this.page.instance) {


### PR DESCRIPTION
To be able to overwrite nprogess as loading indicator as mentioned in inertiajs/inertia#9, this PR adds props to the `Inertia app` for `beforeVisit` and `afterVisit`.