### PR TITLE
Support click listeners on link component

### DIFF
--- a/src/link.js
+++ b/src/link.js
@@ -18,16 +18,6 @@ export default {
     },
   },
   render: function(h, { props, data, children }) {
-    const visit = function (event) {
-      if (shouldIntercept(event)) {
-        event.preventDefault()
-        Inertia.visit(props.href, {
-          method: props.method,
-          replace: props.replace,
-          preserveScroll: props.preserveScroll,
-        })
-      }
-    }
     return h('a', {
       ...data,
       attrs: {
@@ -40,7 +30,15 @@ export default {
           if (data.on && data.on.click) {
             data.on.click(event)
           }
-          visit(event)
+
+          if (shouldIntercept(event)) {
+            event.preventDefault()
+            Inertia.visit(props.href, {
+              method: props.method,
+              replace: props.replace,
+              preserveScroll: props.preserveScroll,
+            })
+          }
         },
       },
     }, children)

--- a/src/link.js
+++ b/src/link.js
@@ -36,7 +36,12 @@ export default {
       },
       on: {
         ...data.on || {},
-        click: visit,
+        click: event => {
+          if (data.on && data.on.click) {
+            data.on.click(event)
+          }
+          visit(event)
+        },
       },
     }, children)
   },


### PR DESCRIPTION
👋 This PR adds support for `click` listeners on a `link` component:

```vue
<template>
  <inertia-link href="/" @click="myClickHandler">Home</inertia-link>
</template>

<script>
export default {
  methods: {
    myClickHandler() {
      // this will now fire on click!
      window.alert('Hello, world')
    }
  }
}
</script>
```

I couldn’t decide whether to put the new logic inside the `visit` function or not ([see the initial commit](https://github.com/inertiajs/inertia-vue/commit/923be2531a24b44d724f967dd610ad0aed8764f2)), and in the end decided to just move it all directly into `on.click`. Since the `visit` function is not reused I think this is the nicest approach. Let me know if you’d prefer it a different way!

Cheers!