### PR TITLE
Replace provide/inject with $page instance property

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -159,13 +159,13 @@ Just like with an `<inertia-link>`, you can set the browser history and scroll b
 
 ## Accessing page data in other components
 
-Sometimes it's necessary to access the page data (props) from a non-page component. One really common use-case for this is the site layout. For example, maybe you want to show the currently authenticated user in your site header. This is possible using Vue's provide/inject features. The base Inertia component automatically "provides" the current page object, which can then be "injected" into any component. Here's a simple example:
+Sometimes it's necessary to access the page data (props) from a non-page component. One really common use-case for this is the site layout. For example, you may want to show the currently authenticated user in the site header. This can be done using the `$page` property. Here's a simple example:
 
 ~~~vue
 <template>
   <main>
     <header>
-      You are logged in as: {{ page.props.auth.user.name }}
+      You are logged in as: {{ $page.auth.user.name }}
 
       <nav>
         <inertia-link href="/">Home</inertia-link>
@@ -179,13 +179,9 @@ Sometimes it's necessary to access the page data (props) from a non-page compone
     </article>
   </main>
 </template>
-
-<script>
-export default {
-  inject: ['page'],
-}
-</script>
 ~~~
+
+This can also be useful for other common "global" data, such as errors and flash messages.
 
 ## Remembering local component state
 

--- a/src/app.js
+++ b/src/app.js
@@ -2,6 +2,8 @@ import Inertia from 'inertia'
 import Link from './link'
 import Remember from './remember'
 
+let app = {}
+
 export default {
   name: 'Inertia',
   props: {
@@ -14,37 +16,32 @@ export default {
       required: true,
     },
   },
-  provide() {
-    return {
-      page: this.page,
-    }
-  },
   data() {
     return {
-      page: {
-        instance: null,
-        props: {},
-      },
+      instance: null,
+      props: {},
     }
   },
   created() {
+    app = this
     Inertia.init(this.initialPage, page =>
       Promise.resolve(this.resolveComponent(page.component)).then(instance => {
-        this.page.instance = instance
-        this.page.props = page.props
+        this.instance = instance
+        this.props = page.props
       })
     )
   },
   render(h) {
-    if (this.page.instance) {
-      return h(this.page.instance, {
+    if (this.instance) {
+      return h(this.instance, {
         key: window.location.pathname,
-        props: this.page.props,
+        props: this.props,
       })
     }
   },
   install(Vue) {
     Object.defineProperty(Vue.prototype, '$inertia', { get: () => Inertia })
+    Object.defineProperty(Vue.prototype, '$page', { get: () => app.props })
     Vue.mixin(Remember)
     Vue.component('InertiaLink', Link)
   },

--- a/src/app.js
+++ b/src/app.js
@@ -15,6 +15,10 @@ export default {
       type: Function,
       required: true,
     },
+    transformProps: {
+      type: Function,
+      default: (props) => props,
+    },
   },
   data() {
     return {
@@ -27,7 +31,7 @@ export default {
     Inertia.init(this.initialPage, page =>
       Promise.resolve(this.resolveComponent(page.component)).then(instance => {
         this.instance = instance
-        this.props = page.props
+        this.props = this.transformProps(page.props)
       })
     )
   },


### PR DESCRIPTION
Resolves #24 
Resolves #19

This removes the currently provide/inject functionality and replaces it with a new `$page` instance property, similar to the `$inertia` property.

Also included in this PR is a new `transformProps()` feature. This was really @thoresuenert's idea (see #19 and #20), I just didn't understand what he was getting at originally. This provides a nice way to modify the props that come back from the server before being sent to the page component. You can almost think of them like prop middleware. Here's an example:

```js
new Vue({
  render: h => h(Inertia, {
    props: {
      initialPage: JSON.parse(app.dataset.page),
      resolveComponent: (page) => pages(`./Pages/${page}.vue`).default,
      transformProps: (props) => {
        return {
          ...props,
          errors: new Errors(props.errors),
        }
      },
    },
  }),
}).$mount(app)
```

**To do:** update docs.