### PR TITLE
Fix console warning 'props with type Object/Array must use a factory…'

### DIFF
--- a/src/link.js
+++ b/src/link.js
@@ -5,7 +5,7 @@ export default {
   props: {
     data: {
       type: Object,
-      default: {},
+      default: () => ({}),
     },
     href: {
       type: String,


### PR DESCRIPTION
Noticed with the latest code, I'm getting lots of fun warnings in the console:

`[Vue warn]: Invalid default value for prop "data": Props with type Object/Array must use a factory function to return the default value.`

Fixed by setting `default: () => ({})` 