### PR TITLE
Store chunkhash in query string

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ mix
   .js('resources/js/app.js', 'public/js')
   .sass('resources/sass/app.scss', 'public/css')
   .webpackConfig({
-    output: { chunkFilename: 'js/[name].[contenthash].js' },
+    output: { chunkFilename: 'js/[name].js?id=[chunkhash]' },
     resolve: {
       alias: {
         vue$: 'vue/dist/vue.runtime.esm.js',


### PR DESCRIPTION
This removes the issue of ending up with 100s of JS files on the machine during development and still maintain cache bypass but inside query string rather than actual file names.