### PR TITLE
added initialPage helper

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -50,6 +50,7 @@ export default {
   install(Vue) {
     Object.defineProperty(Vue.prototype, '$inertia', { get: () => Inertia })
     Object.defineProperty(Vue.prototype, '$page', { get: () => app.props })
+    Object.defineProperty(Vue.prototype, '$initialPage', { get: () => app.initialPage.props })
     Vue.mixin(Remember)
     Vue.component('InertiaLink', Link)
   },


### PR DESCRIPTION
Added the ability to access ```initialPage``` props with ```this.$initialPage```.

This is useful to access props only rendered at the first time.
Example: I'm want load the sidebar menu items once, then I don't need this props for the next requests.

Using Laravel, this props will be in first view composer.