### PR TITLE
Add tag prop to inertia-link

### DIFF
--- a/src/link.js
+++ b/src/link.js
@@ -11,6 +11,10 @@ export default {
       type: String,
       required: true,
     },
+    tag: {
+      type: String,
+      default: 'a',
+    },
     method: {
       type: String,
       default: 'get',
@@ -29,7 +33,7 @@ export default {
     },
   },
   render(h, { props, data, children }) {
-    return h('a', {
+    return h(props.tag, {
       ...data,
       attrs: {
         ...data.attrs,


### PR DESCRIPTION
Add the vue router Tag prop like mentioned in #71. But since it's more than 30 days ago the author of that PR last answered, and this is something people (at least I) are really in need for, I decided to split the 2 features of #71 and push this one myself so at least the tag prop could be merged.