### PR TITLE
Add context to key function in remember option

### DIFF
--- a/src/remember.js
+++ b/src/remember.js
@@ -19,7 +19,7 @@ export default {
     }
 
     const stateKey = this.$options.remember.key instanceof Function
-      ? this.$options.remember.key()
+      ? this.$options.remember.key.apply(this)
       : this.$options.remember.key
 
     const restored = Inertia.restore(stateKey)


### PR DESCRIPTION
The example in the documentation doesn't work:

```JavaScript
{
  remember: {
    data: ['form'],
    key: () =>`Users/Edit:${this.user.id}`,
  },
  data() {
    return {
      form: {
        first_name: this.user.first_name,
        last_name: this.user.last_name,
        // ...
      },
    }
  },
}
```
> Cannot read property 'id' of undefined"

It appears that the `key` function isn't passing the context of the Vue component, but instead the context of the `remember` object.

With the `apply(this)` change in this PR the example still has to be modified a bit:
```JavaScript
remember: {
    data: ['form'],
    key() {
        return `Users/Edit:${this.user.id}`
    }
},
```

**Disclaimer**: I do not have much experience with ES6, so please review/test carefully.