### PR TITLE
Support for class-style component as persistent layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   "typings": "index.d.ts",
   "scripts": {
     "build": "npm run build:cjs && npm run build:umd",
-    "build:cjs": "microbundle --format cjs",
-    "build:umd": "microbundle --format umd --name InertiaVue --globals vue=Vue,@inertiajs/inertia=Inertia",
+    "build:cjs": "microbundle --format cjs --target node",
+    "build:umd": "microbundle --format umd --target node --name InertiaVue --globals vue=Vue,@inertiajs/inertia=Inertia",
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {

--- a/src/app.js
+++ b/src/app.js
@@ -33,7 +33,7 @@ export default {
       initialPage: this.initialPage,
       resolveComponent: this.resolveComponent,
       updatePage: (component, props, { preserveState }) => {
-        this.component = component
+        this.component = component.options || component
         this.props = this.transformProps(props)
         this.key = preserveState ? this.key : Date.now()
       },
@@ -48,7 +48,7 @@ export default {
 
       if (this.component.layout) {
         if (typeof this.component.layout.options !== 'undefined') {
-          this.component.layout = this.component.layout.options;
+          this.component.layout = this.component.layout.options
         }
 
         if (typeof this.component.layout === 'function') {

--- a/src/app.js
+++ b/src/app.js
@@ -47,6 +47,10 @@ export default {
       })
 
       if (this.component.layout) {
+        if (typeof this.component.layout.options !== 'undefined') {
+          this.component.layout = this.component.layout.options;
+        }
+
         if (typeof this.component.layout === 'function') {
           return this.component.layout(h, child)
         }


### PR DESCRIPTION
This PR will add support for class-style component (written in TypeScript) used as persistent layout.

Class based VueComponent have different structure and component object is not available 
on `default` level, as it it actually stored in nested `options` property.
It causes an error in Inertia render function: `TypeError: this._init is not a function`.

The only workaround for now requires to make layout as basic Vue.js component, 
a minor inconvenience, but a problem nonetheless.

