### PR TITLE
Set link preserveState based on method

### DIFF
--- a/src/link.js
+++ b/src/link.js
@@ -25,7 +25,7 @@ export default {
     },
     preserveState: {
       type: Boolean,
-      default: false,
+      default: null,
     },
   },
   render(h, { props, data, children }) {
@@ -50,7 +50,9 @@ export default {
               method: props.method,
               replace: props.replace,
               preserveScroll: props.preserveScroll,
-              preserveState: props.preserveState,
+              preserveState: props.preserveState != null
+                ? props.preserveState
+                : ['post', 'put', 'patch'].includes(props.method),
             })
           }
         },


### PR DESCRIPTION
This PR attempts to fix #111.

However, this is a breaking change as it changes the default for links not including the preserveState prop.