### PR TITLE
InertiaLink "visited" event

### DIFF
--- a/src/link.js
+++ b/src/link.js
@@ -28,7 +28,7 @@ export default {
       default: false,
     },
   },
-  render(h, { props, data, children }) {
+  render(h, { props, data, children, listeners }) {
     return h('a', {
       ...data,
       attrs: {
@@ -37,7 +37,7 @@ export default {
       },
       on: {
         ...(data.on || {}),
-        click: event => {
+        click: async event => {
           if (data.on && data.on.click) {
             data.on.click(event)
           }
@@ -45,13 +45,17 @@ export default {
           if (shouldIntercept(event)) {
             event.preventDefault()
 
-            Inertia.visit(props.href, {
+            await Inertia.visit(props.href, {
               data: props.data,
               method: props.method,
               replace: props.replace,
               preserveScroll: props.preserveScroll,
               preserveState: props.preserveState,
             })
+
+            if (listeners.visited) {
+              listeners.visited()
+            }
           }
         },
       },


### PR DESCRIPTION
This change will fire the "visited" event after the `Inertia.visit` completes.

Simple usage:
```
<inertia-link :href="href" @visited="onVisited">Home</inertia-link>
```

With this functionality, we can now check for the active state or anything else we wanted to do in that `onVisited` or similar method. 