### PR TITLE
feat: recursively resolve nested layouts

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -51,7 +51,7 @@ export default {
           return this.component.layout(h, child)
         }
 
-        return h(this.component.layout, [child])
+        return this.resolveLayout(h, this.component.layout, child);
       }
 
       return child
@@ -62,5 +62,13 @@ export default {
     Object.defineProperty(Vue.prototype, '$page', { get: () => app.props })
     Vue.mixin(Remember)
     Vue.component('InertiaLink', Link)
+  },
+  methods: {
+    resolveLayout(h, layout, child) {
+        child = h(layout, [child]);
+        layout = layout.layout;
+
+        return layout ? this.resolveLayout(h, layout, child) : child;
+    }
   },
 }


### PR DESCRIPTION
The current implementation of nested layouts requires using the render function. This is a) more complex than the the nice layout shorthand and b) requires importing both layouts in every file you use them.

`Page.vue`
```js
  import SiteLayout from './SiteLayout'
  import NestedLayout from './NestedLayout'

  export default {
    layout: (h, page) => {
      return h(SiteLayout, [
        h(NestedLayout, [page]),
      ])
    },
```

For simplicity it would be nice to use the shorthand syntax for nested layouts also.

`InnerLayout.vue`:
```js
  import OuterLayout from './OuterLayout'

  export default {
    layout: OuterLayout,
```

`Page.vue`:
```js
  import InnerLayout from './InnerLayout'

  export default {
    layout: InnerLayout,
```

This PR adds the functionality to recursively resolve nested layouts using the shorthand syntax. 