### PR TITLE
Provide the resolved component to transformProps.

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -34,7 +34,7 @@ export default {
       resolveComponent: this.resolveComponent,
       updatePage: (component, props, { preserveState }) => {
         this.component = component
-        this.props = this.transformProps(props)
+        this.props = this.transformProps(props, component)
         this.key = preserveState ? this.key : Date.now()
       },
     })


### PR DESCRIPTION
For a project I'm working on, we want to have a `transformProps` on each page component. The purpose is so that each page can define how it would like its own props to be prepared.

This PR makes this easier to achieve in userland by providing the component to `transformProps`.

```js
// main.js
const app = document.getElementById('app')

new Vue({
    render: h => h(InertiaApp, {
        props: {
            initialPage: JSON.parse(app.dataset.page),
            resolveComponent: name => import(`@/Pages/${name}`).then(module => module.default),
            transformProps(props, component) {
                component.transformProps = component.transformProps || (() => null)

                return {
                    ...props,
                    ...component.transformProps(props),
                }
            },
        },
    }),
}).$mount(app)

// .../Pages/Organisations/Index.vue
export default {
    props: ['organisations'],
    transformProps(props) {
        return {
            organisations: new OrganisationsCollection(props.organisations),
        }
    },
}
```

Also, is there a contribution guide? Given there are multiple frontend integrations, I wasn't sure if I should PR a `transformProps` for pages feature given I'm only experienced with Vue.